### PR TITLE
setting pydantic <2, as 2 seems to not work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["workflow", "materials-science"]
 dependencies = [
     "msgspec >= 0.14.1",
     "click",
-    "pydantic",
+    "pydantic>=1.10,<2.0",
     "ase",
     "pymatgen",
     "rdkit",


### PR DESCRIPTION
Unless I'm mistaken mkite does not seem compatible with pydantic > 2 (this seems fairly common across other libraries). It might be nice to try and make the whole thing compatible, but in the meanwhile setting the pip install to use pydantic <2 should help avoid users from running the wrong version. 