### PR TITLE
backwards compatible entrypoint access change

### DIFF
--- a/mkite_core/plugins/loader.py
+++ b/mkite_core/plugins/loader.py
@@ -4,10 +4,14 @@ from importlib import metadata
 
 def get_entry_points(name: str) -> List[metadata.EntryPoint]:
     entry_points = metadata.entry_points()
-    if name not in entry_points:
+    if hasattr(entry_points,'select'):
+        return list({e.name:e for e in entry_points.select(group=name)}.values())
+    if isinstance(entry_points,dict):
+        return list(set(entry_points.get(name,[])))
+    try:
+        return list(set(entry_points[name]))
+    except Exception:
         return []
-
-    return list(set(entry_points[name]))
 
 
 def get_recipes() -> Dict[str, metadata.EntryPoint]:


### PR DESCRIPTION
see change: https://importlib-metadata.readthedocs.io/en/latest/api.html#importlib_metadata.entry_points

https://docs.python.org/3/library/importlib.metadata.html

“””Changed in version 3.12: The “selectable” entry points were introduced in importlib_metadata 3.6 and Python 3.10. Prior to those changes, entry_points accepted no parameters and always returned a dictionary of entry points, keyed by group. With importlib_metadata 5.0 and Python 3.12, entry_pointsalways returns an EntryPoints object. See [backports.entry_points_selectable](https://pypi.org/project/backports.entry_points_selectable/) for compatibility options.”””